### PR TITLE
Fix toast hook listener cleanup

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -176,7 +176,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent duplicate listeners in `useToast` hook

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: cannot find type definitions)*