### PR TITLE
Add Vitest and basic utils test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",
@@ -73,6 +74,7 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3",
-    "vite": "^5.1.4"
+    "vite": "^5.1.4",
+    "vitest": "^1.4.0"
   }
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { cn } from '../src/lib/utils';
+
+describe('cn', () => {
+  it('joins class names', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar');
+  });
+
+  it('deduplicates class names', () => {
+    expect(cn('foo', 'foo')).toBe('foo');
+  });
+
+  it('handles conditional classes', () => {
+    expect(cn('foo', { bar: true, baz: false })).toBe('foo bar');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,4 +12,8 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  test: {
+    globals: true,
+    environment: 'node',
+  },
 });


### PR DESCRIPTION
## Summary
- add `vitest` dev dependency and npm test script
- configure Vitest in `vite.config.ts`
- add example test for `cn` utility

## Testing
- `npm test` *(fails: vitest not found)*