### PR TITLE
Fix toast string in handleDelete

### DIFF
--- a/src/components/MoodTracker.tsx
+++ b/src/components/MoodTracker.tsx
@@ -241,7 +241,7 @@ const MoodTracker = () => {
     const newHistory = moodHistory.filter(entry => entry.date !== entryDate);
     setMoodHistory(newHistory);
     localStorage.setItem('moodHistory', JSON.stringify(newHistory));
-    toast.success('Entry deleted! 🗑️');
+    toast.success('Entry deleted! 🗑');
   };
 
   const downloadAllCSV = () => {


### PR DESCRIPTION
## Summary
- close string in `handleDelete`

## Testing
- `npx tsc --noEmit src/components/MoodTracker.tsx` *(fails: Cannot find module 'react' or its corresponding type declarations)*