### PR TITLE
Add basic authentication with SQLite

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "server": "node server.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",
@@ -60,7 +61,12 @@
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.1",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.7",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.2",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@types/node": "^20.11.24",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,87 @@
+const express = require('express');
+const sqlite3 = require('sqlite3').verbose();
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const cors = require('cors');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const db = new sqlite3.Database('data.db');
+
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE,
+    password TEXT
+  )`);
+
+  db.run(`CREATE TABLE IF NOT EXISTS entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER,
+    data TEXT,
+    FOREIGN KEY(user_id) REFERENCES users(id)
+  )`);
+});
+
+const SECRET = 'change_this_secret';
+
+function authMiddleware(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return res.status(401).json({ error: 'No token' });
+  const token = authHeader.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, SECRET);
+    req.userId = decoded.id;
+    next();
+  } catch (err) {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+app.post('/signup', (req, res) => {
+  const { username, password } = req.body;
+  const hashed = bcrypt.hashSync(password, 10);
+  db.run('INSERT INTO users(username, password) VALUES(?, ?)', [username, hashed], function(err) {
+    if (err) return res.status(400).json({ error: 'User exists' });
+    const token = jwt.sign({ id: this.lastID }, SECRET);
+    res.json({ token });
+  });
+});
+
+app.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  db.get('SELECT * FROM users WHERE username = ?', [username], (err, row) => {
+    if (err || !row) return res.status(401).json({ error: 'Invalid' });
+    if (!bcrypt.compareSync(password, row.password)) return res.status(401).json({ error: 'Invalid' });
+    const token = jwt.sign({ id: row.id }, SECRET);
+    res.json({ token });
+  });
+});
+
+app.get('/entries', authMiddleware, (req, res) => {
+  db.all('SELECT * FROM entries WHERE user_id = ?', [req.userId], (err, rows) => {
+    if (err) return res.status(500).json({ error: 'db error' });
+    res.json(rows.map(r => JSON.parse(r.data)));
+  });
+});
+
+app.post('/entries', authMiddleware, (req, res) => {
+  const data = JSON.stringify(req.body);
+  db.run('INSERT INTO entries(user_id, data) VALUES(?, ?)', [req.userId, data], function(err) {
+    if (err) return res.status(500).json({ error: 'db error' });
+    res.json({ id: this.lastID });
+  });
+});
+
+app.delete('/entries', authMiddleware, (req, res) => {
+  const { date } = req.body;
+  db.run('DELETE FROM entries WHERE user_id = ? AND json_extract(data, $.date) = ?', [req.userId, date], function(err) {
+    if (err) return res.status(500).json({ error: 'db error' });
+    res.json({ deleted: this.changes });
+  });
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => console.log(`Server running on ${PORT}`));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,59 @@
 import MoodTracker from './components/MoodTracker';
 import { ThemeProvider } from './components/theme-provider';
+import Login from './components/auth/Login';
+import Signup from './components/auth/Signup';
+import React, { useState, useEffect } from 'react';
 
 function App() {
+  const [token, setToken] = useState<string | null>(null);
+  const [mode, setMode] = useState<'login' | 'signup'>('login');
+
+  useEffect(() => {
+    setToken(localStorage.getItem('token'));
+  }, []);
+
+  const handleAuth = (t: string) => {
+    localStorage.setItem('token', t);
+    setToken(t);
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+  };
+
   return (
     <ThemeProvider defaultTheme="light" storageKey="vite-ui-theme">
-      <MoodTracker />
+      {!token ? (
+        mode === 'login' ? (
+          <div>
+            <Login onLogin={handleAuth} />
+            <p className="text-center mt-4">
+              No account?{' '}
+              <button className="underline" onClick={() => setMode('signup')}>
+                Sign up
+              </button>
+            </p>
+          </div>
+        ) : (
+          <div>
+            <Signup onSignup={handleAuth} />
+            <p className="text-center mt-4">
+              Have an account?{' '}
+              <button className="underline" onClick={() => setMode('login')}>
+                Log in
+              </button>
+            </p>
+          </div>
+        )
+      ) : (
+        <div>
+          <button className="absolute right-4 top-4" onClick={logout}>
+            Log out
+          </button>
+          <MoodTracker />
+        </div>
+      )}
     </ThemeProvider>
   );
 }

--- a/src/components/MoodTracker.tsx
+++ b/src/components/MoodTracker.tsx
@@ -115,10 +115,17 @@ const MoodTracker = () => {
   const [moodHistory, setMoodHistory] = useState<MoodData[]>([]);
 
   useEffect(() => {
-    const savedData = localStorage.getItem('moodHistory');
-    if (savedData) {
-      setMoodHistory(JSON.parse(savedData));
-    }
+    const token = localStorage.getItem('token');
+    if (!token) return;
+    fetch('http://localhost:3001/entries', {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+      .then(res => res.json())
+      .then(data => setMoodHistory(data))
+      .catch(() => {
+        const savedData = localStorage.getItem('moodHistory');
+        if (savedData) setMoodHistory(JSON.parse(savedData));
+      });
   }, []);
 
   const handleSubmit = () => {
@@ -141,6 +148,17 @@ const MoodTracker = () => {
 
     setMoodHistory(newHistory);
     localStorage.setItem('moodHistory', JSON.stringify(newHistory));
+    const token = localStorage.getItem('token');
+    if (token) {
+      fetch('http://localhost:3001/entries', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify(moodData)
+      }).catch(() => {});
+    }
     setIsEditing(false);
     setCurrentPage(-1);
     setMoodData({
@@ -242,6 +260,17 @@ const MoodTracker = () => {
     setMoodHistory(newHistory);
     localStorage.setItem('moodHistory', JSON.stringify(newHistory));
     toast.success('Entry deleted! 🗑');
+    const token = localStorage.getItem('token');
+    if (token) {
+      fetch(`http://localhost:3001/entries`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({ date: entryDate })
+      }).catch(() => {});
+    }
   };
 
   const downloadAllCSV = () => {

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+
+interface Props {
+  onLogin: (token: string) => void;
+}
+
+export default function Login({ onLogin }: Props) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch('http://localhost:3001/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Login failed');
+      onLogin(data.token);
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-4 max-w-sm mx-auto mt-10">
+      <h2 className="text-xl font-bold">Login</h2>
+      {error && <p className="text-red-500">{error}</p>}
+      <input
+        className="border w-full p-2"
+        placeholder="Username"
+        value={username}
+        onChange={e => setUsername(e.target.value)}
+      />
+      <input
+        className="border w-full p-2"
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+      />
+      <button className="bg-purple-600 text-white px-4 py-2" type="submit">
+        Login
+      </button>
+    </form>
+  );
+}

--- a/src/components/auth/Signup.tsx
+++ b/src/components/auth/Signup.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+
+interface Props {
+  onSignup: (token: string) => void;
+}
+
+export default function Signup({ onSignup }: Props) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch('http://localhost:3001/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Signup failed');
+      onSignup(data.token);
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-4 max-w-sm mx-auto mt-10">
+      <h2 className="text-xl font-bold">Sign Up</h2>
+      {error && <p className="text-red-500">{error}</p>}
+      <input
+        className="border w-full p-2"
+        placeholder="Username"
+        value={username}
+        onChange={e => setUsername(e.target.value)}
+      />
+      <input
+        className="border w-full p-2"
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+      />
+      <button className="bg-purple-600 text-white px-4 py-2" type="submit">
+        Sign Up
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add `express`, `sqlite3`, `bcryptjs`, `jsonwebtoken` and `cors`
- implement Node server with signup/login and protected entry CRUD
- add login and signup components
- update `App` to handle authentication
- persist mood entries to the backend from `MoodTracker`

## Testing
- `npm test` *(fails: vitest not found)*