### PR TITLE
Fix signup fetch URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:3001

--- a/src/components/MoodTracker.tsx
+++ b/src/components/MoodTracker.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
 import { motion } from 'framer-motion';
 import { ChevronRight, ChevronLeft, Download, Upload } from 'lucide-react';
 import { format } from 'date-fns';
@@ -117,7 +119,7 @@ const MoodTracker = () => {
   useEffect(() => {
     const token = localStorage.getItem('token');
     if (!token) return;
-    fetch('http://localhost:3001/entries', {
+    fetch(`${API_BASE}/entries`, {
       headers: { Authorization: `Bearer ${token}` }
     })
       .then(res => res.json())
@@ -150,7 +152,7 @@ const MoodTracker = () => {
     localStorage.setItem('moodHistory', JSON.stringify(newHistory));
     const token = localStorage.getItem('token');
     if (token) {
-      fetch('http://localhost:3001/entries', {
+      fetch(`${API_BASE}/entries`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -262,7 +264,7 @@ const MoodTracker = () => {
     toast.success('Entry deleted! 🗑');
     const token = localStorage.getItem('token');
     if (token) {
-      fetch(`http://localhost:3001/entries`, {
+      fetch(`${API_BASE}/entries`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 
+const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+
 interface Props {
   onLogin: (token: string) => void;
 }
@@ -13,7 +15,7 @@ export default function Login({ onLogin }: Props) {
     e.preventDefault();
     setError('');
     try {
-      const res = await fetch('http://localhost:3001/login', {
+      const res = await fetch(`${API_BASE}/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password })

--- a/src/components/auth/Signup.tsx
+++ b/src/components/auth/Signup.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 
+const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+
 interface Props {
   onSignup: (token: string) => void;
 }
@@ -13,7 +15,7 @@ export default function Signup({ onSignup }: Props) {
     e.preventDefault();
     setError('');
     try {
-      const res = await fetch('http://localhost:3001/signup', {
+      const res = await fetch(`${API_BASE}/signup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password })


### PR DESCRIPTION
## Summary
- make the API base URL configurable via `VITE_API_BASE_URL`
- update login, signup and mood tracker to use the env based URL

## Testing
- `npm test --silent`