### PR TITLE
[Utils] Fix whitespace handling in cn helper

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,7 +5,7 @@ export function cn(...inputs: ClassValue[]) {
   // Join classes with clsx, then remove duplicate tokens before applying
   // tailwind-merge so tests expecting deduplication pass consistently.
   const joined = clsx(inputs)
-    .split(' ')
+    .split(/\s+/)
     .filter((c, i, arr) => c && arr.indexOf(c) === i)
     .join(' ');
   return twMerge(joined);

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -13,4 +13,8 @@ describe('cn', () => {
   it('handles conditional classes', () => {
     expect(cn('foo', { bar: true, baz: false })).toBe('foo bar');
   });
+
+  it('handles newlines and extra whitespace', () => {
+    expect(cn('foo\nbar', 'bar')).toBe('foo bar');
+  });
 });


### PR DESCRIPTION
## Summary
- fix whitespace splitting in `cn`
- cover newline and extra whitespace in `cn` tests

## Testing
- `npm run lint`
- `npm test`
